### PR TITLE
Optional support for specifying UserAgent

### DIFF
--- a/opensearch/client.py
+++ b/opensearch/client.py
@@ -20,8 +20,9 @@ class Client:
         print result.title
     """
 
-    def __init__(self, url):
-        self.description = Description(url)
+    def __init__(self, url, agent="OpenSearch Python"):
+        self.agent = agent
+        self.description = Description(url, self.agent)
 
     def search(self, search_terms, page_size=25):
         """Perform a search and get back a results object
@@ -34,5 +35,5 @@ class Client:
         query.count = page_size
 
         # run the results
-        return Results(query)
+        return Results(query, self.agent)
 

--- a/opensearch/description.py
+++ b/opensearch/description.py
@@ -1,4 +1,4 @@
-from urllib2 import urlopen
+from urllib2 import urlopen, Request
 from xml.dom.minidom import parse
 from url import URL
 
@@ -6,11 +6,12 @@ class Description:
     """A class for representing OpenSearch Description files.
     """
 
-    def __init__(self, url=""):
+    def __init__(self, url="", agent=""):
         """The constructor which may pass an optional url to load from.
 
         d = Description("http://www.example.com/description")
         """
+        self.agent = agent
         if url: 
             self.load(url)
 
@@ -19,7 +20,8 @@ class Description:
         """For loading up a description object from a url. Normally
         you'll probably just want to pass a URL into the constructor.
         """
-        self.dom = parse(urlopen(url))
+        req = Request(url, headers={'User-Agent':self.agent})
+        self.dom = parse(urlopen(req))
 
         # version 1.1 has repeating Url elements
         self.urls = self._get_urls()

--- a/opensearch/results.py
+++ b/opensearch/results.py
@@ -2,8 +2,8 @@ from opensearch import osfeedparser
 
 class Results(object):
 
-    def __init__(self,query):
-        self._fetch(query)
+    def __init__(self, query, agent=""):
+        self._fetch(query, agent)
         self._iter = 0
 
     def __iter__(self):
@@ -42,8 +42,8 @@ class Results(object):
                 raise StopIteration
 
 
-    def _fetch(self, query):
-        feed  = osfeedparser.opensearch_parse(query.url())
+    def _fetch(self, query, agent):
+        feed  = osfeedparser.opensearch_parse(query.url(), agent=agent)
         self.feed = feed
 
         # general channel stuff


### PR DESCRIPTION
To pacify strict servers (in my case, wikipedia) which reject requests without a User Agent.
