### PR TITLE
FIX a typo was breaking `text/xml` descriptions #6

### DIFF
--- a/opensearch/description.py
+++ b/opensearch/description.py
@@ -80,7 +80,7 @@ class Description:
 
         # other possible rss type
         if self.get_url_by_type('text/xml'):
-            return self.get_url_by_Type('text/xml').template
+            return self.get_url_by_type('text/xml').template
 
         # otherwise just the first one
         if len(self.urls) > 0:


### PR DESCRIPTION
This should close #6 