### PR TITLE
GitHub Action to lint Python 2.7 code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.9.0-rc.1]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+        python-version: [2.7]  # , 3.9.0-rc.1]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -20,5 +20,6 @@ jobs:
       - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: pip install -r requirements.txt || true
-      - run: pytest . || true
-      - run: pytest --doctest-modules . || true
+      # http://www.koders.com returns Bad Gateway so ignore tests that rely on it
+      - run: pytest --ignore=test/test_client.py --ignore=test/test_results.py .
+      - run: pytest . || true  # For visibility into the http://www.koders.com issues

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,24 @@
+name: lint_python
+on:
+  pull_request:
+  push:
+  #  branches: [master]
+jobs:
+  lint_python:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [2.7, 3.9.0-rc.1]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install codespell flake8 pytest
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: pip install -r requirements.txt || true
+      - run: pytest . || true
+      - run: pytest --doctest-modules . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7]  # , 3.9.0-rc.1]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+        python-version: [2.7]  # , 3.9]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/opensearch/osfeedparser.py
+++ b/opensearch/osfeedparser.py
@@ -2616,7 +2616,7 @@ if __name__ == '__main__':
     for url in urls:
         print url
         print
-        result = parse(url)
+        result = opensearch_parse(url)
         pprint(result)
         print
 


### PR DESCRIPTION
Output: https://github.com/cclauss/opensearch/runs/1098080490?check_suite_focus=true

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.